### PR TITLE
PyTorch_v1 and Python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 experiment_log.txt
 
+snapshots
+
+*env*

--- a/optimization/training.py
+++ b/optimization/training.py
@@ -37,13 +37,13 @@ def train(epoch, train_loader, model, opt, args):
         loss, rec, kl, bpd = calculate_loss(x_mean, data, z_mu, z_var, z0, zk, ldj, args, beta=beta)
 
         loss.backward()
-        train_loss[batch_idx] = loss.data[0]
+        train_loss[batch_idx] = loss.item()
         train_bpd[batch_idx] = bpd
 
         opt.step()
 
-        rec = rec.data[0]
-        kl = kl.data[0]
+        rec = rec.item()
+        kl = kl.item()
 
         num_data += len(data)
 
@@ -51,11 +51,11 @@ def train(epoch, train_loader, model, opt, args):
             if args.input_type == 'binary':
                 print('Epoch: {:3d} [{:5d}/{:5d} ({:2.0f}%)]  \tLoss: {:11.6f}\trec: {:11.6f}\tkl: {:11.6f}'.format(
                     epoch, num_data, len(train_loader.sampler), 100. * batch_idx / len(train_loader),
-                    loss.data[0], rec, kl))
+                    loss.item(), rec, kl))
             else:
                 perc = 100. * batch_idx / len(train_loader)
                 tmp = 'Epoch: {:3d} [{:5d}/{:5d} ({:2.0f}%)] \tLoss: {:11.6f}\tbpd: {:8.6f}'
-                print(tmp.format(epoch, num_data, len(train_loader.sampler), perc, loss.data[0], bpd),
+                print(tmp.format(epoch, num_data, len(train_loader.sampler), perc, loss.item(), bpd),
                       '\trec: {:11.3f}\tkl: {:11.6f}'.format(rec, kl))
 
     if args.input_type == 'binary':
@@ -93,7 +93,7 @@ def evaluate(data_loader, model, args, testing=False, file=None, epoch=0):
         batch_loss, rec, kl, batch_bpd = calculate_loss(x_mean, data, z_mu, z_var, z0, zk, ldj, args)
 
         bpd += batch_bpd
-        loss += batch_loss.data[0]
+        loss += batch_loss.item()
 
         # PRINT RECONSTRUCTIONS
         if batch_idx == 1 and testing is False:
@@ -104,7 +104,7 @@ def evaluate(data_loader, model, args, testing=False, file=None, epoch=0):
 
     # Compute log-likelihood
     if testing:
-        test_data = Variable(data_loader.dataset.data_tensor, volatile=True)
+        test_data = Variable(data_loader.dataset.tensors[0], volatile=True)
 
         if args.cuda:
             test_data = test_data.cuda()

--- a/utils/load_data.py
+++ b/utils/load_data.py
@@ -66,7 +66,7 @@ def load_freyfaces(args, **kwargs):
 
     # start processing
     with open('data/Freyfaces/freyfaces.pkl', 'rb') as f:
-        data = pickle.load(f)[0]
+        data = pickle.load(f, encoding='latin1')[0]
 
     data = data/ 255.
 

--- a/utils/log_likelihood.py
+++ b/utils/log_likelihood.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import numpy as np
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 from optimization.loss import calculate_loss_array
 
 


### PR DESCRIPTION
Hi Rianne,

This PR contains a 'minimal' set of changes to run the code with the latest PyTorch versions and Python 3 ( #1 #2 )

It is 'minimal' in the sense that I only made changes that affect functionality. There are additional cosmetic changes that could be made; e.g. Variable(), the volatile flag, and F.sigmoid() have been deprecated but they should not affect functionality.

I tested the changes with PyTorch 1.0.0 and Python 3.7 on MNIST and Freyfaces, giving me similar results for the baseline VAE without any flows.

I am not sure if more rigorous test should be done and if you want to merge this into master or keep a separate branch.

Best,
Martin